### PR TITLE
Add Windows build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ pip install --upgrade "toolmate[genai]"
 ai -m
 ```
 
+### Build Windows executable
+
+To create a standalone Windows binary, run the helper script `build_toolmate_exe.py`:
+
+```
+python build_toolmate_exe.py
+```
+
+This clones the repository, installs requirements and produces `toolmate.exe` in
+the current directory. Git, Python and pip need to be available on your system.
+
 # Command Line Interface
 
 ToolMate AI 2.0+ offers mainly two commands `toolmate` / `tm` and `toolmatelite` / `tml` to resolve complex and simple tasks respectively.

--- a/build_toolmate_exe.py
+++ b/build_toolmate_exe.py
@@ -1,0 +1,54 @@
+import os
+import subprocess
+import sys
+
+REPO_URL = "https://github.com/eliranwong/toolmate.git"
+REPO_DIR = "toolmate"
+
+
+def run(cmd, cwd=None):
+    print(f"Running: {' '.join(cmd)}")
+    subprocess.check_call(cmd, cwd=cwd)
+
+
+def clone_repo():
+    if not os.path.exists(REPO_DIR):
+        run(["git", "clone", REPO_URL, REPO_DIR])
+    else:
+        print("Repository already cloned")
+
+
+def install_requirements():
+    req_file = os.path.join(REPO_DIR, "package", "toolmate", "requirements.txt")
+    run([sys.executable, "-m", "pip", "install", "--upgrade", "pip"])
+    run([sys.executable, "-m", "pip", "install", "-r", req_file])
+    run([sys.executable, "-m", "pip", "install", "pyinstaller"])
+
+
+def build_exe():
+    main_py = os.path.join(REPO_DIR, "package", "toolmate", "main.py")
+    run(["pyinstaller", "--onefile", "--name", "toolmate", main_py])
+    exe_path = os.path.join("dist", "toolmate.exe")
+    target = os.path.join(os.getcwd(), "toolmate.exe")
+    if os.path.isfile(exe_path):
+        os.replace(exe_path, target)
+        print(f"Executable created: {target}")
+    else:
+        print("pyinstaller did not produce expected executable")
+
+def run_agentmake_setup():
+    try:
+        run([sys.executable, "-m", "agentmake", "-m"])
+    except Exception:
+        print("Skipping agentmake setup step")
+
+
+def main():
+    clone_repo()
+    install_requirements()
+    build_exe()
+    run_agentmake_setup()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `build_toolmate_exe.py` that clones the repo, installs requirements and
  builds `toolmate.exe`
- document how to use the new script in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ac0ec4ea48322bcd0e4ed0f1f87c7